### PR TITLE
Refactor package names and update GitHub Actions workflow: change pac…

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,6 @@ jobs:
           node-version: '20.x'
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
-          scope: '@syucream'
 
       - name: Install dependencies
         run: npm ci
@@ -42,7 +41,7 @@ jobs:
           TAG=${GITHUB_REF#refs/tags/v}
           npm version $TAG --no-git-tag-version
 
-      - name: Publish to GitHub Packages
+      - name: Publish to npm registry
         run: |
           echo "registry=https://registry.npmjs.org/" > .npmrc
           npm publish --access public

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,16 +1,16 @@
 {
   "name": "lightdash-client-example",
   "version": "1.0.0",
-  "description": "Example usage of @syucream/lightdash-client-typescript-fetch",
+  "description": "Example usage of lightdash-client-typescript-fetch",
   "type": "module",
   "main": "index.ts",
   "scripts": {
     "start": "tsx index.ts",
-    "link-local": "cd ../ && npm run build && npm link && cd examples && npm link @syucream/lightdash-client-typescript-fetch",
+    "link-local": "cd ../ && npm run build && npm link && cd examples && npm link lightdash-client-typescript-fetch",
     "dev": "npm run link-local && npm run start"
   },
   "dependencies": {
-    "@syucream/lightdash-client-typescript-fetch": "^0.0.2-202501050102",
+    "lightdash-client-typescript-fetch": "^0.0.2-202501050102",
     "dotenv": "^16.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@syucream/lightdash-client-typescript-fetch",
+  "name": "lightdash-client-typescript-fetch",
   "version": "0.0.3",
   "description": "TypeScript client for Lightdash API generated using openapi-fetch",
   "type": "module",


### PR DESCRIPTION
…kage name from @syucream/lightdash-client-typescript-fetch to lightdash-client-typescript-fetch, update example usage description, and modify publish step to target npm registry directly.